### PR TITLE
fix: events no longer can be comma separated

### DIFF
--- a/lua/based.lua
+++ b/lua/based.lua
@@ -133,7 +133,7 @@ end
 
 
 -- Clear all hints when something happens
-vim.api.nvim_create_autocmd("CursorMoved,ModeChanged,WinLeave", {
+vim.api.nvim_create_autocmd({"CursorMoved", "ModeChanged", "WinLeave"}, {
     pattern = "*",
     group = vim.api.nvim_create_augroup("Based", { clear = true }),
     callback = clear_hints,


### PR DESCRIPTION
Same reason as https://github.com/jakewvincent/mkdnflow.nvim/pull/176

After neovim/neovim#25523 the comma separated events are not valid any
more and will throw error
